### PR TITLE
Fix: Index as keys - Issue#10

### DIFF
--- a/client/src/components/customers/customers.js
+++ b/client/src/components/customers/customers.js
@@ -30,8 +30,9 @@ class Customers extends React.Component {
           {this.state.customers.length === 0 && (
             <p>No customers available</p>
           )}
-          {this.state.customers.map((customer, index) => (
-            <li key={index}>{customer.name}</li>
+          {this.state.customers.map((customer) => (
+            <li key={customer.id}>{customer.name}</li>
+            
           ))}
         </ul>
       </div>


### PR DESCRIPTION
Instead of using `index` as keys, we can use `customer.id`. This will improve rendering efficiency and UI consistency.

closes #10 